### PR TITLE
non-root install

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ please create a pull request.
 1) To build the `gd-tools` you need to install `xmake` and `gcc` (13.1 and newer).
 2) Run `./quickinstall.sh`.
 
+   **Note:** You can run `./quickinstall.sh --local`
+   to install the program locally (to `~/.local/` ).
+
 </details>
+
+## Setup
 
 Open GoldenDict, press "Edit" > "Dictionaries" > "Programs" and add the installed executables.
 Set type to `html`.

--- a/quickinstall.sh
+++ b/quickinstall.sh
@@ -6,4 +6,12 @@ set -xeuo pipefail
 
 xmake f -m release
 xmake build -vwy
-xmake install -v --all --installdir=~/.local/
+
+case ${1-} in
+--local | --user)
+    xmake install -v --all --installdir=~/.local/
+    ;;
+*)
+    xmake install -v --all --installdir=/usr --admin
+    ;;
+esac

--- a/quickinstall.sh
+++ b/quickinstall.sh
@@ -6,4 +6,4 @@ set -xeuo pipefail
 
 xmake f -m release
 xmake build -vwy
-xmake install -v --all --installdir=~/.local/bin/ 
+xmake install -v --all --installdir=~/.local/

--- a/quickinstall.sh
+++ b/quickinstall.sh
@@ -6,4 +6,4 @@ set -xeuo pipefail
 
 xmake f -m release
 xmake build -vwy
-xmake install -v --all --installdir=/usr --admin
+xmake install -v --all --installdir=~/.local/bin/ 

--- a/src/marisa.cpp
+++ b/src/marisa.cpp
@@ -20,7 +20,6 @@
 #include "precompiled.h"
 #include "util.h"
 
-// TODO search dict.dic in more locations
 // TODO convert half width chars to full width chars
 // TODO inflections; fix things like グラついた
 // 首をなでられた
@@ -70,11 +69,26 @@ static constexpr std::string_view css_style = R"EOF(
 )EOF";
 static constexpr std::size_t max_forward_search_len_bytes{ CharByteLen::THREE * 10UL };
 
+auto find_dic_file() -> std::filesystem::path
+{
+  static const auto locations = {
+    // possible .dic locations
+    std::filesystem::path("/usr/share/gd-tools/marisa_words.dic"),
+    std::filesystem::path(std::getenv("HOME")) / ".local/share/gd-tools/marisa_words.dic"
+  };
+  for (auto const& location: locations) {
+    if (std::filesystem::exists(location) and std::filesystem::is_regular_file(location)) {
+      return location;
+    }
+  }
+  throw runtime_error("Couldn't find the word list.");
+}
+
 struct marisa_params
 {
   std::string gd_word{};
   std::string gd_sentence{};
-  std::string path_to_dic{ "/usr/share/gd-tools/marisa_words.dic" };
+  std::string path_to_dic{ find_dic_file() };
 
   auto assign(std::string_view const key, std::string_view const value) -> void
   {


### PR DESCRIPTION
this fixes some permission bugs in gentoo, but it might fix some bugs in other distros as well

i think that there's no need to run gd-tools as root

since the files on the res folder are supposed to be installed on root directories, i manually copied them, but you could make a conditional to copy the files to some non-root directory (maybe under ~/.local/share/) 