### PR TITLE
fmtlib replaced with std::format

### DIFF
--- a/src/anki_search.cpp
+++ b/src/anki_search.cpp
@@ -274,7 +274,7 @@ void print_table_header(search_params const& params)
   gd::print("<th>Deck name</th>");
   for (auto const& field: params.show_fields) { gd::print("<th>{}</th>", field); }
   gd::print("<th>Tags</th>");
-  gd::print("</tr>\n");
+  gd::println("</tr>");
 }
 
 auto card_json_to_obj(nlohmann::json const& card_json) -> card_info
@@ -311,11 +311,11 @@ void print_cards_info(search_params const& params)
 {
   auto const cids = find_cids(params);
   if (cids.empty()) {
-    return gd::print("No cards found.\n");
+    return gd::println("No cards found.");
   }
   auto const media_dir_path = fetch_media_dir_path();
   gd::print("<div class=\"gd-table-wrap\">");
-  gd::print("<table class=\"gd-ankisearch-table\">\n");
+  gd::println("<table class=\"gd-ankisearch-table\">");
   print_table_header(params);
   for (auto const& card: get_cids_info(cids) | std::views::transform(card_json_to_obj)) {
     gd::print("<tr class=\"{}\">", determine_card_class(card.queue, card.type));
@@ -329,12 +329,12 @@ void print_cards_info(search_params const& params)
            : "Not present")
       );
     }
-    gd::print("<td>{}</td>\n", get_note_tags(card.nid));
-    gd::print("</tr>\n");
+    gd::println("<td>{}</td>", get_note_tags(card.nid));
+    gd::println("</tr>");
   }
   gd::print("</table>");
-  gd::print("</div>\n"); // gd-table-wrap
-  gd::print("{}\n", css_style);
+  gd::println("</div>"); // gd-table-wrap
+  gd::println("{}", css_style);
 }
 
 void search_anki_cards(std::span<std::string_view const> const args)
@@ -344,6 +344,6 @@ void search_anki_cards(std::span<std::string_view const> const args)
   } catch (gd::help_requested const& ex) {
     gd::print(help_text);
   } catch (gd::runtime_error const& ex) {
-    gd::print("{}\n", ex.what());
+    gd::println("{}", ex.what());
   }
 }

--- a/src/anki_search.cpp
+++ b/src/anki_search.cpp
@@ -167,10 +167,10 @@ auto make_find_cards_request_str(search_params const& params) -> std::string
   std::string query{ params.gd_word };
 
   if (not params.field_name.empty()) {
-    query = fmt::format("\"{}:*{}*\"", params.field_name, query);
+    query = std::format("\"{}:*{}*\"", params.field_name, query);
   }
   if (not params.deck_name.empty()) {
-    query = fmt::format("\"deck:{}\" {}", params.deck_name, query);
+    query = std::format("\"deck:{}\" {}", params.deck_name, query);
   }
 
   request["params"]["query"] = query;
@@ -261,7 +261,7 @@ auto get_note_tags(uint64_t const nid) -> std::string
   raise_if(not obj["error"].is_null(), "Error getting data from AnkiConnect.");
   std::string html;
   for (std::string const tag_name: obj["result"]) {
-    html += fmt::format(R"EOF(<a class="gd-tag-link" href="ankisearch:tag:{}">{}</a>)EOF", tag_name, tag_name);
+    html += std::format(R"EOF(<a class="gd-tag-link" href="ankisearch:tag:{}">{}</a>)EOF", tag_name, tag_name);
   }
   return html;
 }
@@ -269,12 +269,12 @@ auto get_note_tags(uint64_t const nid) -> std::string
 void print_table_header(search_params const& params)
 {
   // Print the first row (header) that contains <th></th> tags, starting with Card ID.
-  fmt::print("<tr>");
-  fmt::print("<th>Card ID</th>");
-  fmt::print("<th>Deck name</th>");
-  for (auto const& field: params.show_fields) { fmt::print("<th>{}</th>", field); }
-  fmt::print("<th>Tags</th>");
-  fmt::print("</tr>\n");
+  gd::print("<tr>");
+  gd::print("<th>Card ID</th>");
+  gd::print("<th>Deck name</th>");
+  for (auto const& field: params.show_fields) { gd::print("<th>{}</th>", field); }
+  gd::print("<th>Tags</th>");
+  gd::print("</tr>\n");
 }
 
 auto card_json_to_obj(nlohmann::json const& card_json) -> card_info
@@ -303,38 +303,38 @@ auto gd_format(std::string const& field_content, std::string const& media_dir_pa
   static std::regex const img_re{ "(<img[^<>]*src=\")" };
   static std::regex const any_undesirables{ R"EOF(\[sound:|\]|<[^<>]+>|["'.,!?]+|…|。|、|！|？|　|・|～|\(|\))EOF" };
   auto const link_content = strtrim(std::regex_replace(field_content, any_undesirables, " "));
-  auto const link_text = std::regex_replace(field_content, img_re, fmt::format("$1file://{}/", media_dir_path));
-  return link_content.empty() ? link_text : fmt::format("<a href=\"ankisearch:{}\">{}</a>", link_content, link_text);
+  auto const link_text = std::regex_replace(field_content, img_re, std::format("$1file://{}/", media_dir_path));
+  return link_content.empty() ? link_text : std::format("<a href=\"ankisearch:{}\">{}</a>", link_content, link_text);
 }
 
 void print_cards_info(search_params const& params)
 {
   auto const cids = find_cids(params);
   if (cids.empty()) {
-    return fmt::print("No cards found.\n");
+    return gd::print("No cards found.\n");
   }
   auto const media_dir_path = fetch_media_dir_path();
-  fmt::print("<div class=\"gd-table-wrap\">");
-  fmt::print("<table class=\"gd-ankisearch-table\">\n");
+  gd::print("<div class=\"gd-table-wrap\">");
+  gd::print("<table class=\"gd-ankisearch-table\">\n");
   print_table_header(params);
   for (auto const& card: get_cids_info(cids) | std::views::transform(card_json_to_obj)) {
-    fmt::print("<tr class=\"{}\">", determine_card_class(card.queue, card.type));
-    fmt::print("<td><a href=\"ankisearch:cid:{}\">{}</a></td>", card.id, card.id);
-    fmt::print("<td>{}</td>", card.deck_name);
+    gd::print("<tr class=\"{}\">", determine_card_class(card.queue, card.type));
+    gd::print("<td><a href=\"ankisearch:cid:{}\">{}</a></td>", card.id, card.id);
+    gd::print("<td>{}</td>", card.deck_name);
     for (auto const& field_name: params.show_fields) {
-      fmt::print(
+      gd::print(
         "<td>{}</td>",
         (card.fields.contains(field_name) and not card.fields.at(field_name).empty()
            ? gd_format(card.fields.at(field_name), media_dir_path)
            : "Not present")
       );
     }
-    fmt::print("<td>{}</td>\n", get_note_tags(card.nid));
-    fmt::print("</tr>\n");
+    gd::print("<td>{}</td>\n", get_note_tags(card.nid));
+    gd::print("</tr>\n");
   }
-  fmt::print("</table>");
-  fmt::print("</div>\n"); // gd-table-wrap
-  fmt::print("{}\n", css_style);
+  gd::print("</table>");
+  gd::print("</div>\n"); // gd-table-wrap
+  gd::print("{}\n", css_style);
 }
 
 void search_anki_cards(std::span<std::string_view const> const args)
@@ -342,8 +342,8 @@ void search_anki_cards(std::span<std::string_view const> const args)
   try {
     print_cards_info(fill_args<search_params>(args));
   } catch (gd::help_requested const& ex) {
-    fmt::print(help_text);
+    gd::print(help_text);
   } catch (gd::runtime_error const& ex) {
-    fmt::print("{}\n", ex.what());
+    gd::print("{}\n", ex.what());
   }
 }

--- a/src/echo.cpp
+++ b/src/echo.cpp
@@ -69,13 +69,13 @@ void print_css(stroke_order_params const& params)
   }}
   </style>
   )EOF";
-  fmt::print(css, this_pid, params.font_size, params.font_family);
+  gd::print(css, this_pid, params.font_size, params.font_family);
 }
 
 void print_with_stroke_order(stroke_order_params const& params)
 {
   if (params.gd_word.length() <= params.max_len) {
-    fmt::print("<div class=\"gd_echo_{}\">{}</div>\n", this_pid, params.gd_word);
+    gd::print("<div class=\"gd_echo_{}\">{}</div>\n", this_pid, params.gd_word);
     print_css(params);
   }
 }
@@ -85,8 +85,8 @@ void stroke_order(std::span<std::string_view const> const args)
   try {
     print_with_stroke_order(fill_args<stroke_order_params>(args));
   } catch (gd::help_requested const& ex) {
-    fmt::print(help_text);
+    gd::print(help_text);
   } catch (gd::runtime_error const& ex) {
-    fmt::print("{}\n", ex.what());
+    gd::print("{}\n", ex.what());
   }
 }

--- a/src/echo.cpp
+++ b/src/echo.cpp
@@ -75,7 +75,7 @@ void print_css(stroke_order_params const& params)
 void print_with_stroke_order(stroke_order_params const& params)
 {
   if (params.gd_word.length() <= params.max_len) {
-    gd::print("<div class=\"gd_echo_{}\">{}</div>\n", this_pid, params.gd_word);
+    gd::println("<div class=\"gd_echo_{}\">{}</div>", this_pid, params.gd_word);
     print_css(params);
   }
 }
@@ -87,6 +87,6 @@ void stroke_order(std::span<std::string_view const> const args)
   } catch (gd::help_requested const& ex) {
     gd::print(help_text);
   } catch (gd::runtime_error const& ex) {
-    gd::print("{}\n", ex.what());
+    gd::println("{}", ex.what());
   }
 }

--- a/src/images.cpp
+++ b/src/images.cpp
@@ -84,12 +84,12 @@ void fetch_images(images_params const& params)
   static std::regex const img_re("<img[^<>]*class=\"mimg[^<>]*>");
   auto images_begin = std::sregex_iterator(std::begin(r.text), std::end(r.text), img_re);
   auto images_end = std::sregex_iterator();
-  fmt::print("<div class=\"gallery\">\n");
+  gd::print("<div class=\"gallery\">\n");
   for (auto const& match: std::ranges::subrange(images_begin, images_end) | std::views::take(5)) {
-    fmt::print("{}\n", match.str());
+    gd::print("{}\n", match.str());
   }
-  fmt::print("</div>\n");
-  fmt::print("{}\n", css_style);
+  gd::print("</div>\n");
+  gd::print("{}\n", css_style);
 }
 
 void images(std::span<std::string_view const> const args)
@@ -97,8 +97,8 @@ void images(std::span<std::string_view const> const args)
   try {
     fetch_images(fill_args<images_params>(args));
   } catch (gd::help_requested const& ex) {
-    fmt::print(help_text);
+    gd::print(help_text);
   } catch (gd::runtime_error const& ex) {
-    fmt::print("{}\n", ex.what());
+    gd::print("{}\n", ex.what());
   }
 }

--- a/src/images.cpp
+++ b/src/images.cpp
@@ -84,12 +84,12 @@ void fetch_images(images_params const& params)
   static std::regex const img_re("<img[^<>]*class=\"mimg[^<>]*>");
   auto images_begin = std::sregex_iterator(std::begin(r.text), std::end(r.text), img_re);
   auto images_end = std::sregex_iterator();
-  gd::print("<div class=\"gallery\">\n");
+  gd::println("<div class=\"gallery\">");
   for (auto const& match: std::ranges::subrange(images_begin, images_end) | std::views::take(5)) {
-    gd::print("{}\n", match.str());
+    gd::println("{}", match.str());
   }
-  gd::print("</div>\n");
-  gd::print("{}\n", css_style);
+  gd::println("</div>");
+  gd::println("{}", css_style);
 }
 
 void images(std::span<std::string_view const> const args)
@@ -99,6 +99,6 @@ void images(std::span<std::string_view const> const args)
   } catch (gd::help_requested const& ex) {
     gd::print(help_text);
   } catch (gd::runtime_error const& ex) {
-    gd::print("{}\n", ex.what());
+    gd::println("{}", ex.what());
   }
 }

--- a/src/kana_conv.cpp
+++ b/src/kana_conv.cpp
@@ -39,7 +39,7 @@ auto unicode_char_byte_len(char const& ch) -> CharByteLen
     // Other Unicode
     return CharByteLen::FOUR;
   }
-  throw gd::runtime_error{ fmt::format("Can't recognize byte: '{:x}'.", ch) };
+  throw gd::runtime_error{ std::format("Can't recognize byte: '{:x}'.", ch) };
 }
 
 auto create_map(std::string_view from, std::string_view to) -> KanaConvMap

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 #include "massif.h"
 #include "mecab_split.h"
 #include "precompiled.h"
+#include "util.h"
 
 static constexpr std::string_view help_text = R"EOF(usage: {} ACTION [OPTIONS]
 A set of helpful programs to enhance GoldenDict for immersion learning.
@@ -47,12 +48,12 @@ gd-ankisearch --deck-name Mining %GDWORD%
 
 auto get_help_str(std::string_view program_name) -> std::string
 {
-  return fmt::format(help_text, program_name);
+  return std::format(help_text, program_name);
 }
 
 auto print_help(std::string_view const program_name) -> void
 {
-  fmt::print("{}", get_help_str(program_name));
+  gd::print("{}", get_help_str(program_name));
 }
 
 auto base_name(auto file_path) -> std::string

--- a/src/marisa_split.cpp
+++ b/src/marisa_split.cpp
@@ -181,10 +181,10 @@ void lookup_words(marisa_params params)
   marisa::Agent agent;
 
   std::ifstream file{ params.path_to_dic };
-  raise_if(not file.good(), fmt::format(R"(Error. The dictionary file "{}" does not exist.)", params.path_to_dic));
+  raise_if(not file.good(), std::format(R"(Error. The dictionary file "{}" does not exist.)", params.path_to_dic));
   trie.load(params.path_to_dic.c_str());
 
-  fmt::println(R"(<div class="gd-marisa">)");
+  gd::println(R"(<div class="gd-marisa">)");
   std::ptrdiff_t pos_in_gd_word{ 0 };
   std::vector<JpSet> alternatives{};
   alternatives.reserve(20);
@@ -205,7 +205,7 @@ void lookup_words(marisa_params params)
       pos_in_gd_word -= static_cast<std::ptrdiff_t>(uni_char.length());
     }
 
-    fmt::print(
+    gd::print(
       R"(<a class="{}" href="bword:{}">{}</a>)",
       (pos_in_gd_word > 0 ? "gd-headword" : "gd-word"),
       bword,
@@ -215,23 +215,23 @@ void lookup_words(marisa_params params)
   }
 
   // Show available entries for other substrings.
-  fmt::println(R"(<div class="alternatives">)");
+  gd::println(R"(<div class="alternatives">)");
   for (auto const& group: alternatives | std::views::filter(&JpSet::size)) {
-    fmt::println("<ul>");
+    gd::println("<ul>");
     for (auto const& word: group) {
-      fmt::println(
+      gd::println(
         R"(<li><a class="{}" href="bword:{}">{}</a></li>)",
         (word == params.gd_word ? "gd-headword" : ""),
         word,
         word
       );
     }
-    fmt::println("</ul>"); // close ul
+    gd::println("</ul>"); // close ul
   }
-  fmt::println("</div>"); // close div.alternatives
+  gd::println("</div>"); // close div.alternatives
 
-  fmt::println("</div>"); // close div.gd-marisa
-  fmt::println("{}", css_style);
+  gd::println("</div>"); // close div.gd-marisa
+  gd::println("{}", css_style);
 }
 
 void marisa_split(std::span<std::string_view const> const args)
@@ -239,8 +239,8 @@ void marisa_split(std::span<std::string_view const> const args)
   try {
     lookup_words(fill_args<marisa_params>(args));
   } catch (gd::help_requested const& ex) {
-    fmt::println(help_text);
+    gd::println(help_text);
   } catch (gd::runtime_error const& ex) {
-    fmt::println("{}", ex.what());
+    gd::println("{}", ex.what());
   }
 }

--- a/src/massif.cpp
+++ b/src/massif.cpp
@@ -74,12 +74,12 @@ struct massif_params
 void fetch_massif_examples(massif_params const& params)
 {
   cpr::Response const r = cpr::Get(
-    cpr::Url{ fmt::format("https://massif.la/ja/search?q={}", params.gd_word) },
+    cpr::Url{ std::format("https://massif.la/ja/search?q={}", params.gd_word) },
     cpr::Timeout{ params.max_time },
     cpr::VerifySsl{ false }
   );
   raise_if(r.status_code != 200, "Couldn't connect to Massif.");
-  fmt::print("<ul class=\"gd-massif\">\n");
+  gd::print("<ul class=\"gd-massif\">\n");
   for (auto const& line:
        r.text //
          | std::views::split('\n') //
@@ -88,10 +88,10 @@ void fetch_massif_examples(massif_params const& params)
              return not str_view.contains("<li class=\"text-japanese\">");
            })
          | std::views::take_while([](auto const str_view) { return not str_view.contains("</ul>"); })) {
-    fmt::print("{}\n", line);
+    gd::print("{}\n", line);
   }
-  fmt::print("</ul>\n");
-  fmt::print("{}\n", css_style);
+  gd::print("</ul>\n");
+  gd::print("{}\n", css_style);
 }
 
 void massif(std::span<std::string_view const> const args)
@@ -99,8 +99,8 @@ void massif(std::span<std::string_view const> const args)
   try {
     fetch_massif_examples(fill_args<massif_params>(args));
   } catch (gd::help_requested const& ex) {
-    fmt::print(help_text);
+    gd::print(help_text);
   } catch (gd::runtime_error const& ex) {
-    fmt::print("{}\n", ex.what());
+    gd::print("{}\n", ex.what());
   }
 }

--- a/src/massif.cpp
+++ b/src/massif.cpp
@@ -79,7 +79,7 @@ void fetch_massif_examples(massif_params const& params)
     cpr::VerifySsl{ false }
   );
   raise_if(r.status_code != 200, "Couldn't connect to Massif.");
-  gd::print("<ul class=\"gd-massif\">\n");
+  gd::println("<ul class=\"gd-massif\">");
   for (auto const& line:
        r.text //
          | std::views::split('\n') //
@@ -88,10 +88,10 @@ void fetch_massif_examples(massif_params const& params)
              return not str_view.contains("<li class=\"text-japanese\">");
            })
          | std::views::take_while([](auto const str_view) { return not str_view.contains("</ul>"); })) {
-    gd::print("{}\n", line);
+    gd::println("{}", line);
   }
-  gd::print("</ul>\n");
-  gd::print("{}\n", css_style);
+  gd::println("</ul>");
+  gd::println("{}", css_style);
 }
 
 void massif(std::span<std::string_view const> const args)
@@ -101,6 +101,6 @@ void massif(std::span<std::string_view const> const args)
   } catch (gd::help_requested const& ex) {
     gd::print(help_text);
   } catch (gd::runtime_error const& ex) {
-    gd::print("{}\n", ex.what());
+    gd::println("{}", ex.what());
   }
 }

--- a/src/mecab_split.cpp
+++ b/src/mecab_split.cpp
@@ -121,7 +121,7 @@ struct mecab_params
     } else if (key == "--user-dict") {
       user_dict = value;
     } else {
-      throw gd::runtime_error(std::string(fmt::format("Unknown argument name: {}", key)));
+      throw gd::runtime_error(std::string(std::format("Unknown argument name: {}", key)));
     }
   }
 };
@@ -174,16 +174,18 @@ void lookup_words(mecab_params params)
   }
 
   std::string result = tagger->parse(params.gd_sentence.c_str());
-  result = replace_all(result, fmt::format(">{}<", params.gd_word), fmt::format("><b>{}</b><", params.gd_word));
-  fmt::println(R"EOF(<div class="gd-mecab">{}</div>)EOF", result);
-  fmt::println("{}", css_style);
+  result = replace_all(result, std::format(">{}<", params.gd_word), std::format("><b>{}</b><", params.gd_word));
+  gd::println(R"EOF(<div class="gd-mecab">{}</div>)EOF", result);
+  gd::println("{}", css_style);
 
   // debug info, not shown in GD.
-  fmt::println(R"EOF(<div style="display: none;">)EOF");
-  fmt::println("dicdir: {}", params.dic_dir.string());
-  fmt::println("userdic: {}", params.user_dict.string());
-  fmt::println("mecab args: {}", args);
-  fmt::println(R"EOF(</div>)EOF");
+  gd::println(R"EOF(<div style="display: none;">)EOF");
+  gd::println("dicdir: {}", params.dic_dir.string());
+  gd::println("userdic: {}", params.user_dict.string());
+
+  //TODO There must be a better way but ranges are not supported yet as far as I know
+  gd::println("mecab args: {} {} {} {} {}", args[0], args[1], args[2], args[3], args[4]);
+  gd::println(R"EOF(</div>)EOF");
 }
 
 void mecab_split(std::span<std::string_view const> const args)
@@ -191,8 +193,8 @@ void mecab_split(std::span<std::string_view const> const args)
   try {
     lookup_words(fill_args<mecab_params>(args));
   } catch (gd::help_requested const& ex) {
-    fmt::println(help_text);
+    gd::println(help_text);
   } catch (gd::runtime_error const& ex) {
-    fmt::println("{}", ex.what());
+    gd::println("{}", ex.what());
   }
 }

--- a/src/mecab_split.cpp
+++ b/src/mecab_split.cpp
@@ -183,8 +183,7 @@ void lookup_words(mecab_params params)
   gd::println("dicdir: {}", params.dic_dir.string());
   gd::println("userdic: {}", params.user_dict.string());
 
-  //TODO There must be a better way but ranges are not supported yet as far as I know
-  gd::println("mecab args: {} {} {} {} {}", args[0], args[1], args[2], args[3], args[4]);
+  gd::println("mecab args: [{}]", join_with(args, ", "));
   gd::println(R"EOF(</div>)EOF");
 }
 

--- a/src/precompiled.h
+++ b/src/precompiled.h
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <system_error>
 #include <vector>
+#include <format>
 
 // Getpid
 #if __linux__
@@ -27,8 +28,7 @@
 
 // Other
 #include <cpr/cpr.h>
-#include <fmt/core.h>
-#include <fmt/ranges.h>
+
 #include <marisa/trie.h>
 #include <mecab.h>
 #include <nlohmann/json.hpp>

--- a/src/precompiled.h
+++ b/src/precompiled.h
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <concepts>
 #include <filesystem>
+#include <format>
 #include <iomanip>
 #include <iostream>
 #include <iterator>
@@ -17,7 +18,6 @@
 #include <string_view>
 #include <system_error>
 #include <vector>
-#include <format>
 
 // Getpid
 #if __linux__

--- a/src/util.h
+++ b/src/util.h
@@ -15,23 +15,23 @@ public:
   runtime_error(std::string_view const what) : std::runtime_error(std::string{ what }) {}
 };
 
+template<typename... Args>
+void print(std::string_view format, Args const&... args)
+{
+  std::string result;
+  result = std::vformat(format, std::make_format_args(args...));
+  std::ios::sync_with_stdio(false);
+  std::cout << result;
+}
 
-template <typename... Args>
-void print(std::string_view format, const Args&... args) {
-    std::string result;
-	result = std::vformat(format, std::make_format_args(args...));
-    std::ios::sync_with_stdio(false);
-    std::cout << result;
-    }
-
-template <typename... Args>
-void println(std::string_view format, const Args&... args) {
-    std::string result;
-	result = std::vformat(format, std::make_format_args(args...));
-    std::ios::sync_with_stdio(false);
-    std::cout << result << '\n';
-    }
-
+template<typename... Args>
+void println(std::string_view format, Args const&... args)
+{
+  std::string result;
+  result = std::vformat(format, std::make_format_args(args...));
+  std::ios::sync_with_stdio(false);
+  std::cout << result << '\n';
+}
 
 } // namespace gd
 

--- a/src/util.h
+++ b/src/util.h
@@ -14,6 +14,25 @@ class runtime_error : public std::runtime_error
 public:
   runtime_error(std::string_view const what) : std::runtime_error(std::string{ what }) {}
 };
+
+
+template <typename... Args>
+void print(std::string_view format, const Args&... args) {
+    std::string result;
+	result = std::vformat(format, std::make_format_args(args...));
+    std::ios::sync_with_stdio(false);
+    std::cout << result;
+    }
+
+template <typename... Args>
+void println(std::string_view format, const Args&... args) {
+    std::string result;
+	result = std::vformat(format, std::make_format_args(args...));
+    std::ios::sync_with_stdio(false);
+    std::cout << result << '\n';
+    }
+
+
 } // namespace gd
 
 inline void raise_if(bool expr, std::string_view const message = "Invalid argument.")

--- a/src/util.h
+++ b/src/util.h
@@ -104,3 +104,16 @@ inline auto user_home() -> std::filesystem::path
 {
   return std::getenv("HOME");
 }
+
+template<typename Stored>
+auto join_with(std::vector<Stored> const& seq, std::string_view const sep) -> std::string
+{
+  std::stringstream ss;
+  for (size_t idx = 0; idx != seq.size(); ++idx) {
+    ss << seq.at(idx);
+    if (idx != seq.size() - 1) {
+      ss << sep;
+    }
+  }
+  return ss.str();
+}

--- a/xmake.lua
+++ b/xmake.lua
@@ -1,6 +1,6 @@
 local main_bin_name = "gd-tools"
 set_license("GPL-3.0")
-set_languages("c++2b")
+set_languages("c++23")
 set_toolchains("gcc")
 
 set_warnings("allextra", "error")
@@ -13,7 +13,7 @@ add_rules("mode.debug", "mode.release")
 -- https://clangd.llvm.org/installation#project-setup
 add_rules("plugin.compile_commands.autoupdate", {outputdir = "build"})
 
-add_requires("mecab", "cpr >= 1.10.5", "fmt >= 10.2", "nlohmann_json", "marisa", "rdricpp")
+add_requires("cpr >= 1.10.5", "nlohmann_json", "marisa", "rdricpp", "mecab")
 
 if is_mode("debug") then
     add_defines("DEBUG")
@@ -60,7 +60,7 @@ end
 -- Main target
 target(main_bin_name)
     set_kind("binary")
-    add_packages("cpr", "fmt", "nlohmann_json", "marisa", "rdricpp", "mecab")
+    add_packages("cpr","nlohmann_json", "marisa", "rdricpp", "mecab")
     add_files("src/*.cpp")
     add_cxflags("-D_GLIBCXX_ASSERTIONS")
     set_pcxxheader("src/precompiled.h")
@@ -130,7 +130,7 @@ if has_config("tests") then
     -- Tests target
     target("tests")
         set_kind("binary")
-        add_packages("cpr", "fmt", "nlohmann_json", "marisa", "catch2", "rdricpp", "mecab")
+        add_packages("cpr","nlohmann_json", "marisa", "catch2", "rdricpp", "mecab")
         add_files("src/*.cpp", "tests/*.cpp")
         remove_files("src/main.cpp")
         set_pcxxheader("src/precompiled.h")


### PR DESCRIPTION
libFmt causes compilation and linking errors on Windows, Fedora 39, Guix, Freebsd. 
C++23 includes std::format which can replace it.  

This patch removes dependency on fmt and introduces replacement functions for `fmt::print` and `fmt::println` making gd-tools ready to be cross platform and less prone to OS/Distro specific library issues.

However, it looks like ranges are not yet supported in std::format and I don't know how to implement it.
Check  mecab_split.cpp at line 186, I can't test gd-mecab since it's not working on my OS
