### PR TITLE
gd-mecab, fix crash and add a possible directory for mecab

### DIFF
--- a/src/mecab_split.cpp
+++ b/src/mecab_split.cpp
@@ -73,6 +73,9 @@ auto find_file_recursive(
 ) -> std::filesystem::path
 {
   for (size_t idx = 0; idx < possible_dirs.size(); ++idx) {
+    if (!std::filesystem::is_directory(possible_dirs[idx])) {
+      continue;
+    }
     for (auto const& dir_entry: std::filesystem::directory_iterator(possible_dirs.at(idx))) {
       if (dir_entry.is_regular_file() and dir_entry.path().filename() == file_name) {
         return dir_entry.path();
@@ -99,6 +102,7 @@ auto find_dic_dir() -> std::filesystem::path
   static std::vector<std::filesystem::path> const possible_dirs = {
     "/usr/lib/mecab/dic/mecab-ipadic-neologd", // neologd is preferred if available
     "/usr/lib/mecab/dic",
+    "/usr/lib64/mecab/dic",
     user_home() / ".local/share/Anki2/addons21",
   };
   // parent path of an empty entry returns itself.


### PR DESCRIPTION
mecab was installed in /usr/lib64/ on Fedora 41
When installed with --local, /usr/share/gd-tools doesn't exist, but gd-mecab still tries to check files in it resulting in an unhandled exception and a crash.